### PR TITLE
Added basic composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "loop54/php-connector",
+    "type": "library",
+    "description": "PHP Wrapper for Loop54 JSON API",
+    "homepage": "http://docs.loop54.com",
+    "autoload": {
+        "files": ["dist/Loop54-Minified.php"]
+    },
+    "require": {
+        "php": ">=5.5"
+    }
+}


### PR DESCRIPTION
This PR adds a basic composer.json file to easily include the library to projects. In practice, it simply registers Loop54-Minified.php file as a include path to composer autoloader.