### PR TITLE
48B81HF7: updated with complementary results;

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ process. First we generate the code from the specification and write it to a
 temporary location.
 
     openapi-generator-cli generate \
-        -g php -i schema.json -o ~/tmp/phpgen
+        -g php -i schema.json -o ~/tmp/phpgen \
         --invoker-package 'Loop54\API\OpenAPI'
 
 this generates also a bunch of supporting code that we're not very interested

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "homepage": "https://openapi-generator.tech"
     }],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "loop54/php-connector",
     "description": "Wrapper around the API for querying your Loop54 engine.",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "type": "library",
     "keywords": ["search", "service", "api", "ecommerce"],
     "homepage": "https://github.com/LoopFiftyFour/PHP-Connector",

--- a/examples/Simple.php
+++ b/examples/Simple.php
@@ -237,7 +237,7 @@ function getRelatedEntities($connector)
     $request = $connector->getRelatedEntities($connector->entity('Product', 12));
     /* Take only 10 items */
     $request->resultsOptions()->take(10);
-    //$request->relationKind('similar');
+//     $request->relationKind('similar');    // this line is commented because "helloworld" engine does not support relationKind yet
     
     // CODE SAMPLE END
 

--- a/examples/Simple.php
+++ b/examples/Simple.php
@@ -237,6 +237,7 @@ function getRelatedEntities($connector)
     $request = $connector->getRelatedEntities($connector->entity('Product', 12));
     /* Take only 10 items */
     $request->resultsOptions()->take(10);
+    //$request->relationKind('similar');
     
     // CODE SAMPLE END
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -8,7 +8,7 @@ class Client
     use OpenAPIWrapper;
 
     const APIVERSION = 'V3';
-    const LIBVERSION = 'php:V3:1.0.6';
+    const LIBVERSION = 'php:V3:1.1.0';
     private $apikey;
     private $remoteClientInfo;
     private $httpClient;

--- a/lib/GetRelatedEntitiesRequest.php
+++ b/lib/GetRelatedEntitiesRequest.php
@@ -27,6 +27,11 @@ class GetRelatedEntitiesRequest implements Request
         }
         return new ResultsOptions($this->getRaw()->getResultsOptions());
     }
+    
+    public function relationKind($relKind)
+    {
+        $this->getRaw()->setRelationKind($relKind);
+    }
 
     public function perform(
         $instance,

--- a/lib/OpenAPI/Model/GetRelatedEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetRelatedEntitiesRequest.php
@@ -60,6 +60,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     protected static $openAPITypes = [
         'entity' => 'Entity',
         'results_options' => 'EntityCollectionParameters',
+        'relation_kind' => 'string',
         'custom_data' => 'map[string,object]'
     ];
 
@@ -71,6 +72,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     protected static $openAPIFormats = [
         'entity' => null,
         'results_options' => null,
+        'relation_kind' => null,
         'custom_data' => null
     ];
 
@@ -103,6 +105,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'entity' => 'entity',
         'results_options' => 'resultsOptions',
+        'relation_kind' => 'relationKind',
         'custom_data' => 'customData'
     ];
 
@@ -114,6 +117,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     protected static $setters = [
         'entity' => 'setEntity',
         'results_options' => 'setResultsOptions',
+        'relation_kind' => 'setRelationKind',
         'custom_data' => 'setCustomData'
     ];
 
@@ -125,6 +129,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     protected static $getters = [
         'entity' => 'getEntity',
         'results_options' => 'getResultsOptions',
+        'relation_kind' => 'getRelationKind',
         'custom_data' => 'getCustomData'
     ];
 
@@ -169,9 +174,21 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
         return self::$openAPIModelName;
     }
 
-    
+    const RELATION_KIND_SIMILAR = 'similar';
+    const RELATION_KIND_COMPLEMENTARY = 'complementary';
 
-    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getRelationKindAllowableValues()
+    {
+        return [
+            self::RELATION_KIND_SIMILAR,
+            self::RELATION_KIND_COMPLEMENTARY,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -190,6 +207,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     {
         $this->container['entity'] = isset($data['entity']) ? $data['entity'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;
+        $this->container['relation_kind'] = isset($data['relation_kind']) ? $data['relation_kind'] : null;
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;
     }
 
@@ -205,6 +223,15 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
         if ($this->container['entity'] === null) {
             $invalidProperties[] = "'entity' can't be null";
         }
+        $allowedValues = $this->getRelationKindAllowableValues();
+        if (!is_null($this->container['relation_kind']) && !in_array($this->container['relation_kind'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'relation_kind', must be one of '%s'",
+                $this->container['relation_kind'],
+                implode("', '", $allowedValues)
+            );
+        }
+
         return $invalidProperties;
     }
 
@@ -264,6 +291,40 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
     public function setResultsOptions($results_options)
     {
         $this->container['results_options'] = $results_options;
+
+        return $this;
+    }
+
+    /**
+     * Gets relation_kind
+     *
+     * @return string|null
+     */
+    public function getRelationKind()
+    {
+        return $this->container['relation_kind'];
+    }
+
+    /**
+     * Sets relation_kind
+     *
+     * @param string|null $relation_kind Represents the type of relation that would be done. 'Similar' is more of the same, 'complementary' is 'people also buy'
+     *
+     * @return self
+     */
+    public function setRelationKind($relation_kind)
+    {
+        $allowedValues = $this->getRelationKindAllowableValues();
+        if (!is_null($relation_kind) && !in_array($relation_kind, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'relation_kind', must be one of '%s'",
+                    $relation_kind,
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['relation_kind'] = $relation_kind;
 
         return $this;
     }

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -391,6 +391,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
                 ResultsOptions::ORDER_DESC,
                 'Price'
             );
+        //$request->relationKind('similar');    // this line is commented because "helloworld" engine does not support relationKind yet
 
         $response = $connector->query($request);
 

--- a/test/OpenAPI/Model/GetRelatedEntitiesRequestTest.php
+++ b/test/OpenAPI/Model/GetRelatedEntitiesRequestTest.php
@@ -91,6 +91,13 @@ class GetRelatedEntitiesRequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test attribute "relation_kind"
+     */
+    public function testPropertyRelationKind()
+    {
+    }
+    
+    /**
      * Test attribute "custom_data"
      */
     public function testPropertyCustomData()


### PR DESCRIPTION
The examples actually doesn't work with PHP 5.6 on my machine, so we may want to update specified minimum reqs (or fix the errors).

This updates GetRelatedEntities request with `relationKind` field, able to distinguish between 'similar' (current behaviour *more of the same*) and 'complementary' (recommendations, *people also buy*).