### PR TITLE
OnrAlLK4: Require any PHP version starting with 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "homepage": "https://openapi-generator.tech"
     }],
     "require": {
-        "php": ">=7.4",
+        "php": "^7.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
The reason we require specifically version 7 is that the OpenAPI generator generates PHP code in that dialect.

Requiring 7.4 or later is probably a bit too restrictive: Ubuntu 18.04 (which we use for our own servers) only ships
with 7.2. Of course, you can install a newer version on your own, but I only want to require this of our customers if
it's truly necessary.

Test plan:

1. Ensure this builds on the CI server, where the build agents run PHP 7.2.