### PR TITLE
vVbueqiz: Rename build script, drop branch req. on plain build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if [ -n "$do_publish" -a "$do_publish" != "publish" ]; then
 fi
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "master" ]; then
+if [ "$do_publish" = "publish" -a "$current_branch" != "master" ]; then
     echo "Expected to publish master branch, not $current_branch"
     exit 1
 fi


### PR DESCRIPTION
We only want to require the master branch when publishing.

Also, it's counter-intuitive to run ./publish.sh to run a plain build, and ./publish.sh publish to publish. Better to
run ./build.sh to build and ./build.sh publish to publish. Hence the renamed script!

Test plan:

1. Run ./build.sh on a non-master branch, watch it build (but not publish!)
2. Run ./build.sh publish on a non-master branch, watch it error out before doing anything.