### PR TITLE
vVbueqiz: Check also for empty confirmation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,11 +73,12 @@ if [ "$do_publish" = "publish" ]; then
         read confirmation
     fi
 
-    if [ $confirmation != 'y' -a $confirmation != 'Y' ]; then
+    if [ -n "$confirmation" -a $confirmation = 'y' ]; then
+        git push origin HEAD
+        git push origin "$tag_name"
+    else
         echo 'Failed to get confirmation. Not pushing.'
         exit 0
     fi
 
-    git push origin HEAD
-    git push origin "$tag_name"
 fi


### PR DESCRIPTION
The build server doesn't supply any input (instant EOF on any read) so the confirmation variable was empty, and this got
interpreted as invalid syntax to test, which then went ahead with the deployment anyway! Not what we want. So
we check whether it's empty first.

To be extra safe, we also invert the conditional.