### PR TITLE
ISSUE#32: Fix argument order in getPopularEntities method

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -191,7 +191,7 @@ class Client
      */
     public function getPopularEntities($behaviorType, $forUserId = null, $entityType = null)
     {
-        return new GetPopularEntitiesRequest($behaviorType, $forUserId, $entityType);
+        return new GetPopularEntitiesRequest($behaviorType, $entityType, $forUserId);
     }
 
     /**

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -208,7 +208,7 @@ class Client
      */
     public function getRecentEntities($behaviorType, $forUserId = null, $entityType = null)
     {
-        return new GetRecentEntitiesRequest($behaviorType, $forUserId, $entityType);
+        return new GetRecentEntitiesRequest($behaviorType, $entityType, $forUserId);
     }
 
     /**


### PR DESCRIPTION
Fix argument order in getPopularEntities method
Fix for: https://github.com/LoopFiftyFour/PHP-Connector/issues/32