### PR TITLE
add support for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "loop54/php-connector",
     "description": "Wrapper around the API for querying your Loop54 engine.",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "type": "library",
     "keywords": ["search", "service", "api", "ecommerce"],
     "homepage": "https://github.com/LoopFiftyFour/PHP-Connector",
@@ -14,7 +14,7 @@
         "homepage": "https://openapi-generator.tech"
     }],
     "require": {
-        "php": "7.3 - 8",
+        "php": "7.3 - 8.4",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -8,7 +8,7 @@ class Client
     use OpenAPIWrapper;
 
     const APIVERSION = 'V3';
-    const LIBVERSION = 'php:V3:3.0.3';
+    const LIBVERSION = 'php:V3:3.0.4';
     private $apikey;
     private $remoteClientInfo;
     private $httpClient;

--- a/lib/OpenAPI/Api/AdministrativeApi.php
+++ b/lib/OpenAPI/Api/AdministrativeApi.php
@@ -70,9 +70,9 @@ class AdministrativeApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/OpenAPI/Api/OtherApi.php
+++ b/lib/OpenAPI/Api/OtherApi.php
@@ -70,9 +70,9 @@ class OtherApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/OpenAPI/Api/UserInitiatedApi.php
+++ b/lib/OpenAPI/Api/UserInitiatedApi.php
@@ -70,9 +70,9 @@ class UserInitiatedApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/OpenAPI/Model/AndFilterParameter.php
+++ b/lib/OpenAPI/Model/AndFilterParameter.php
@@ -168,7 +168,7 @@ class AndFilterParameter extends FilterParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/AttributeExistsFilterParameter.php
+++ b/lib/OpenAPI/Model/AttributeExistsFilterParameter.php
@@ -168,7 +168,7 @@ class AttributeExistsFilterParameter extends FilterParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/AttributeFilterParameter.php
+++ b/lib/OpenAPI/Model/AttributeFilterParameter.php
@@ -223,7 +223,7 @@ class AttributeFilterParameter extends FilterParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/AttributeNameValuePair.php
+++ b/lib/OpenAPI/Model/AttributeNameValuePair.php
@@ -181,7 +181,7 @@ class AttributeNameValuePair implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/lib/OpenAPI/Model/AutoCompleteRequest.php
+++ b/lib/OpenAPI/Model/AutoCompleteRequest.php
@@ -186,7 +186,7 @@ class AutoCompleteRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['query'] = isset($data['query']) ? $data['query'] : null;
         $this->container['queries_options'] = isset($data['queries_options']) ? $data['queries_options'] : null;

--- a/lib/OpenAPI/Model/AutoCompleteResponse.php
+++ b/lib/OpenAPI/Model/AutoCompleteResponse.php
@@ -178,7 +178,7 @@ class AutoCompleteResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/CreateEventsRequest.php
+++ b/lib/OpenAPI/Model/CreateEventsRequest.php
@@ -181,7 +181,7 @@ class CreateEventsRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;

--- a/lib/OpenAPI/Model/CustomRequest.php
+++ b/lib/OpenAPI/Model/CustomRequest.php
@@ -176,7 +176,7 @@ class CustomRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;
     }

--- a/lib/OpenAPI/Model/DistinctFacet.php
+++ b/lib/OpenAPI/Model/DistinctFacet.php
@@ -168,7 +168,7 @@ class DistinctFacet extends Facet
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/DistinctFacetItem.php
+++ b/lib/OpenAPI/Model/DistinctFacetItem.php
@@ -186,7 +186,7 @@ class DistinctFacetItem implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['item'] = isset($data['item']) ? $data['item'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/OpenAPI/Model/DistinctFacetItemSortingParameter.php
+++ b/lib/OpenAPI/Model/DistinctFacetItemSortingParameter.php
@@ -213,7 +213,7 @@ class DistinctFacetItemSortingParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : 'count';
         $this->container['order'] = isset($data['order']) ? $data['order'] : 'desc';

--- a/lib/OpenAPI/Model/DistinctFacetParameter.php
+++ b/lib/OpenAPI/Model/DistinctFacetParameter.php
@@ -173,7 +173,7 @@ class DistinctFacetParameter extends FacetParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/Entity.php
+++ b/lib/OpenAPI/Model/Entity.php
@@ -186,7 +186,7 @@ class Entity implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/OpenAPI/Model/EntityAttributes.php
+++ b/lib/OpenAPI/Model/EntityAttributes.php
@@ -210,7 +210,7 @@ class EntityAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/lib/OpenAPI/Model/EntityCollection.php
+++ b/lib/OpenAPI/Model/EntityCollection.php
@@ -186,7 +186,7 @@ class EntityCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['facets'] = isset($data['facets']) ? $data['facets'] : null;

--- a/lib/OpenAPI/Model/EntityCollectionParameters.php
+++ b/lib/OpenAPI/Model/EntityCollectionParameters.php
@@ -196,7 +196,7 @@ class EntityCollectionParameters implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['skip'] = isset($data['skip']) ? $data['skip'] : 0;
         $this->container['take'] = isset($data['take']) ? $data['take'] : 5;

--- a/lib/OpenAPI/Model/EntitySortingParameter.php
+++ b/lib/OpenAPI/Model/EntitySortingParameter.php
@@ -222,7 +222,7 @@ class EntitySortingParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : 'relevance';
         $this->container['attribute_name'] = isset($data['attribute_name']) ? $data['attribute_name'] : null;

--- a/lib/OpenAPI/Model/ErrorDetails.php
+++ b/lib/OpenAPI/Model/ErrorDetails.php
@@ -196,7 +196,7 @@ class ErrorDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;

--- a/lib/OpenAPI/Model/ErrorResponse.php
+++ b/lib/OpenAPI/Model/ErrorResponse.php
@@ -173,7 +173,7 @@ class ErrorResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/Event.php
+++ b/lib/OpenAPI/Model/Event.php
@@ -196,7 +196,7 @@ class Event implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['entity'] = isset($data['entity']) ? $data['entity'] : null;

--- a/lib/OpenAPI/Model/Facet.php
+++ b/lib/OpenAPI/Model/Facet.php
@@ -201,7 +201,7 @@ class Facet implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/lib/OpenAPI/Model/FacetParameter.php
+++ b/lib/OpenAPI/Model/FacetParameter.php
@@ -201,7 +201,7 @@ class FacetParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attribute_name'] = isset($data['attribute_name']) ? $data['attribute_name'] : null;

--- a/lib/OpenAPI/Model/FilterParameter.php
+++ b/lib/OpenAPI/Model/FilterParameter.php
@@ -176,7 +176,7 @@ class FilterParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/OpenAPI/Model/GetBasketRecommendationsRequest.php
+++ b/lib/OpenAPI/Model/GetBasketRecommendationsRequest.php
@@ -186,7 +186,7 @@ class GetBasketRecommendationsRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['entities'] = isset($data['entities']) ? $data['entities'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;

--- a/lib/OpenAPI/Model/GetBasketRecommendationsResponse.php
+++ b/lib/OpenAPI/Model/GetBasketRecommendationsResponse.php
@@ -173,7 +173,7 @@ class GetBasketRecommendationsResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetComplementaryEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetComplementaryEntitiesRequest.php
@@ -186,7 +186,7 @@ class GetComplementaryEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['entity'] = isset($data['entity']) ? $data['entity'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;

--- a/lib/OpenAPI/Model/GetComplementaryEntitiesResponse.php
+++ b/lib/OpenAPI/Model/GetComplementaryEntitiesResponse.php
@@ -173,7 +173,7 @@ class GetComplementaryEntitiesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetEntitiesByAttributeRequest.php
+++ b/lib/OpenAPI/Model/GetEntitiesByAttributeRequest.php
@@ -191,7 +191,7 @@ class GetEntitiesByAttributeRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attribute'] = isset($data['attribute']) ? $data['attribute'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;

--- a/lib/OpenAPI/Model/GetEntitiesByAttributeResponse.php
+++ b/lib/OpenAPI/Model/GetEntitiesByAttributeResponse.php
@@ -173,7 +173,7 @@ class GetEntitiesByAttributeResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetEntitiesRequest.php
@@ -181,7 +181,7 @@ class GetEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;

--- a/lib/OpenAPI/Model/GetEntitiesResponse.php
+++ b/lib/OpenAPI/Model/GetEntitiesResponse.php
@@ -173,7 +173,7 @@ class GetEntitiesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetIndexedAttributeValuesRequest.php
+++ b/lib/OpenAPI/Model/GetIndexedAttributeValuesRequest.php
@@ -181,7 +181,7 @@ class GetIndexedAttributeValuesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attribute_name'] = isset($data['attribute_name']) ? $data['attribute_name'] : null;
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;

--- a/lib/OpenAPI/Model/GetIndexedAttributeValuesResponse.php
+++ b/lib/OpenAPI/Model/GetIndexedAttributeValuesResponse.php
@@ -173,7 +173,7 @@ class GetIndexedAttributeValuesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetIndexedAttributesRequest.php
+++ b/lib/OpenAPI/Model/GetIndexedAttributesRequest.php
@@ -176,7 +176,7 @@ class GetIndexedAttributesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;
     }

--- a/lib/OpenAPI/Model/GetIndexedAttributesResponse.php
+++ b/lib/OpenAPI/Model/GetIndexedAttributesResponse.php
@@ -178,7 +178,7 @@ class GetIndexedAttributesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetPopularEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetPopularEntitiesRequest.php
@@ -196,7 +196,7 @@ class GetPopularEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['behavior_type'] = isset($data['behavior_type']) ? $data['behavior_type'] : null;
         $this->container['entity_type'] = isset($data['entity_type']) ? $data['entity_type'] : null;

--- a/lib/OpenAPI/Model/GetRecentEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetRecentEntitiesRequest.php
@@ -196,7 +196,7 @@ class GetRecentEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['behavior_type'] = isset($data['behavior_type']) ? $data['behavior_type'] : null;
         $this->container['entity_type'] = isset($data['entity_type']) ? $data['entity_type'] : null;

--- a/lib/OpenAPI/Model/GetRecommendedEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetRecommendedEntitiesRequest.php
@@ -181,7 +181,7 @@ class GetRecommendedEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;

--- a/lib/OpenAPI/Model/GetRecommendedEntitiesResponse.php
+++ b/lib/OpenAPI/Model/GetRecommendedEntitiesResponse.php
@@ -173,7 +173,7 @@ class GetRecommendedEntitiesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/GetRelatedEntitiesRequest.php
+++ b/lib/OpenAPI/Model/GetRelatedEntitiesRequest.php
@@ -186,7 +186,7 @@ class GetRelatedEntitiesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['entity'] = isset($data['entity']) ? $data['entity'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;

--- a/lib/OpenAPI/Model/GetRelatedEntitiesResponse.php
+++ b/lib/OpenAPI/Model/GetRelatedEntitiesResponse.php
@@ -173,7 +173,7 @@ class GetRelatedEntitiesResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/InverseFilterParameter.php
+++ b/lib/OpenAPI/Model/InverseFilterParameter.php
@@ -168,7 +168,7 @@ class InverseFilterParameter extends FilterParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/OrFilterParameter.php
+++ b/lib/OpenAPI/Model/OrFilterParameter.php
@@ -168,7 +168,7 @@ class OrFilterParameter extends FilterParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/QueryCollection.php
+++ b/lib/OpenAPI/Model/QueryCollection.php
@@ -181,7 +181,7 @@ class QueryCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;

--- a/lib/OpenAPI/Model/QueryCollectionParameters.php
+++ b/lib/OpenAPI/Model/QueryCollectionParameters.php
@@ -186,7 +186,7 @@ class QueryCollectionParameters implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['skip'] = isset($data['skip']) ? $data['skip'] : 0;
         $this->container['take'] = isset($data['take']) ? $data['take'] : 5;

--- a/lib/OpenAPI/Model/QueryResult.php
+++ b/lib/OpenAPI/Model/QueryResult.php
@@ -176,7 +176,7 @@ class QueryResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['query'] = isset($data['query']) ? $data['query'] : null;
     }

--- a/lib/OpenAPI/Model/QuerySortingParameter.php
+++ b/lib/OpenAPI/Model/QuerySortingParameter.php
@@ -213,7 +213,7 @@ class QuerySortingParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : 'relevance';
         $this->container['order'] = isset($data['order']) ? $data['order'] : 'desc';

--- a/lib/OpenAPI/Model/RangeFacet.php
+++ b/lib/OpenAPI/Model/RangeFacet.php
@@ -183,7 +183,7 @@ class RangeFacet extends Facet
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/RangeFacetParameter.php
+++ b/lib/OpenAPI/Model/RangeFacetParameter.php
@@ -168,7 +168,7 @@ class RangeFacetParameter extends FacetParameter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/RangeFacetSelectedParameter.php
+++ b/lib/OpenAPI/Model/RangeFacetSelectedParameter.php
@@ -181,7 +181,7 @@ class RangeFacetSelectedParameter implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['min'] = isset($data['min']) ? $data['min'] : null;
         $this->container['max'] = isset($data['max']) ? $data['max'] : null;

--- a/lib/OpenAPI/Model/RequestAliasFields.php
+++ b/lib/OpenAPI/Model/RequestAliasFields.php
@@ -186,7 +186,7 @@ class RequestAliasFields implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/lib/OpenAPI/Model/Response.php
+++ b/lib/OpenAPI/Model/Response.php
@@ -176,7 +176,7 @@ class Response implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;
     }

--- a/lib/OpenAPI/Model/ScopedQueryResult.php
+++ b/lib/OpenAPI/Model/ScopedQueryResult.php
@@ -173,7 +173,7 @@ class ScopedQueryResult extends QueryResult
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/SearchRequest.php
+++ b/lib/OpenAPI/Model/SearchRequest.php
@@ -201,7 +201,7 @@ class SearchRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['query'] = isset($data['query']) ? $data['query'] : null;
         $this->container['results_options'] = isset($data['results_options']) ? $data['results_options'] : null;

--- a/lib/OpenAPI/Model/SearchResponse.php
+++ b/lib/OpenAPI/Model/SearchResponse.php
@@ -198,7 +198,7 @@ class SearchResponse extends Response
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/OpenAPI/Model/SyncRequest.php
+++ b/lib/OpenAPI/Model/SyncRequest.php
@@ -176,7 +176,7 @@ class SyncRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['custom_data'] = isset($data['custom_data']) ? $data['custom_data'] : null;
     }

--- a/lib/OpenAPI/Model/UnScopedQueryResult.php
+++ b/lib/OpenAPI/Model/UnScopedQueryResult.php
@@ -168,7 +168,7 @@ class UnScopedQueryResult extends QueryResult
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/test-matrix.sh
+++ b/test-matrix.sh
@@ -15,3 +15,5 @@ test 7.4
 test 8.0
 test 8.1
 test 8.2
+test 8.3
+test 8.4


### PR DESCRIPTION
Updated constructors to use explicit nullable types (?type) instead of 
implicit null defaults. Tested with PHP 8.3 and 8.4.
